### PR TITLE
Fix raw bluetooth mode

### DIFF
--- a/ds4drv/backends/bluetooth.py
+++ b/ds4drv/backends/bluetooth.py
@@ -86,7 +86,7 @@ class BluetoothBackend(Backend):
     def setup(self):
         """Check if the bluetooth controller is available."""
         try:
-            subprocess.check_output(["bluetoothctl", "", "list"],
+            subprocess.check_output(["bluetoothctl", "list"],
                                     stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError:
             raise BackendError("'bluetoothctl returned error. Make sure "


### PR DESCRIPTION
For my system,
```
CalledProcessError: Command '['bluetoothctl', '', 'list']' returned non-zero exit status 1.
```

Workaround: 
use
```
subprocess.check_output(["bluetoothctl", "list"], stderr=subprocess.STDOUT)
```